### PR TITLE
Removal of Sam2

### DIFF
--- a/tracking/track_players.py
+++ b/tracking/track_players.py
@@ -1,17 +1,12 @@
 from ultralytics import YOLO
 import supervision as sv
 import sys
-from ultralytics import SAM
-import numpy as np
-import random
-
 sys.path.append("../")
 
 class PlayerTracker():
     def __init__(self, model_path):
         self.model = YOLO(model_path)
         self.tracker = sv.ByteTrack()
-        self.sam2 = SAM("sam2.1_b.pt")
 
     def detect_frames(self, vid_frames, batch_size=20, min_conf=0.5):
         detections = []
@@ -21,61 +16,17 @@ class PlayerTracker():
             detections += batch_detections
         return detections
     
-    def mask_to_bbox(self, mask):
-        ys, xs = np.where(mask > 0)
-        if len(xs) == 0 or len(ys) == 0:
-            return [0, 0, mask.shape[1], mask.shape[0]]
-        
-        x_min = int(xs.min())
-        x_max = int(xs.max())
-        y_min = int(ys.min())
-        y_max = int(ys.max())
-        
-        return [x_min, y_min, x_max, y_max]
-    
     def get_object_tracks(self, vid_frames):
-        
+
         detections = self.detect_frames(vid_frames)
 
         tracks = []
-        total = len(vid_frames)
-        for frame_id, frame in enumerate(vid_frames):
-            print(f"frame {frame_id}/{total}")
-            detection = detections[frame_id]
+        for frame_id, detection in enumerate(detections):
             class_names =  detection.names
             class_names_inv = {val:key for key,val in class_names.items()}  
             detection_sv = sv.Detections.from_ultralytics(detection)
-
-            refined_bboxes = []
-            for det in detection_sv:
-                bbox_array = det[0]
-                x1, y1, x2, y2 = map(int, bbox_array)
-                conf = float(det[2])
-                class_id = int(det[3])
-
-                if class_names_inv['Player'] != class_id:
-                    continue  # skip non-player detections
-
-                player_crop = frame[y1:y2, x1:x2]
-
-                # SAM2 mask
-                results = self.sam2(player_crop, bboxes=[[0,0,x2-x1, y2-y1]])
-                mask = results[0].masks.data[0].cpu().numpy().astype(np.uint8)
-
-                x_min_rel, y_min_rel, x_max_rel, y_max_rel = self.mask_to_bbox(mask)
-
-                x1_ref = x1 + x_min_rel
-                y1_ref = y1 + y_min_rel
-                x2_ref = x1 + x_max_rel
-                y2_ref = y1 + y_max_rel
-
-                refined_bboxes.append([x1_ref, y1_ref, x2_ref, y2_ref, conf, class_id])
-
-            xyxy = np.array([b[:4] for b in refined_bboxes])
-            confidences = np.array([b[4] for b in refined_bboxes])
-            class_ids = np.array([b[5] for b in refined_bboxes])
-            detections_sv = sv.Detections(xyxy=xyxy, confidence=confidences, class_id=class_ids)
-            detection_with_tracks = self.tracker.update_with_detections(detections_sv)
+            detection_with_tracks = self.tracker.update_with_detections(detection_sv)
+            
             tracks.append({})
 
             for frame_detection in detection_with_tracks:
@@ -85,8 +36,5 @@ class PlayerTracker():
 
                 if class_id == class_names_inv["Player"]:
                     tracks[frame_id][track_id] = {"bbox": bbox}
-            
 
         return tracks
-              
-


### PR DESCRIPTION
### TL;DR
- Faster inference without Sam2 in the Team Assigner as well as Player Tracking.
- Performance is on par, if not even better, without Sam2.

### Background
Originally, Sam2 was utilized to create player masks in both team assigner and player tracking. As for the team assigner Sam2 was used to blur out the background in hopes of helping make the predictions of the CLIP Model more accurate, which assigns the player the jersey color, so we can infer the team. Finally, as for the player tracking Sam2 was used to refine the bounding boxes generated by the YOLO model to make them more "tight" to further help reduce background noise.

The problem is that Sam2 greatly increased the inference speeds, as well as the performance gain being negligible or even non-existent.

The problems we wanted to be solved originally, which were robust team tracking of the individual players, seem to have been solved to a large extent by simply introducing historical tracking with majority voting of the past team assignments for each player.

Original PR which introduced Sam2 #16 

### Historical Tracking with majority voting as well as cropping of the images. Sam2 and Caching Excluded.
https://github.com/user-attachments/assets/b463bac7-9d17-402c-b143-f029ecc3ce8b


