### PR TITLE
updated team assigner service to run batched framewise on gpu

### DIFF
--- a/services/team_assigner_service/team_assigner_service.py
+++ b/services/team_assigner_service/team_assigner_service.py
@@ -55,9 +55,6 @@ async def assign_teams(
         vid_frames=frames,
         player_tracks=player_tracks,
     )
-    for key, time in team_assigner.times.items():
-        print(f"{key}: {time}")
-    print(team_assigner.device)
 
     # Serialize
     payload = {

--- a/team_assigner/team_assigner.py
+++ b/team_assigner/team_assigner.py
@@ -88,7 +88,6 @@ class TeamAssigner:
         return 1 if most_freq == self.team_A else 2
 
     def get_player_team(self,frame,player_bbox,player_id):
-        start = time()
         player_color = self.get_player_color(frame,player_bbox)
         self.player_team_cache_history[player_id].append(player_color)
         team_id = self.get_team_from_history(player_id)


### PR DESCRIPTION
Updated team assigner service,
- running clip on gpu batched per frame.
- initializing class on startup
- loading model on startup

Improvement from approximately 54 seconds to 3.3 seconds.

Timing of major components (5070TI):
trax: 5.700890064239502
team assignment: 3.285994052886963
ball possesion: 0.006055355072021484
homography: 4.391351938247681
full draw: 0.7931160926818848