### PR TITLE
passes & interceptions #24

### DIFF
--- a/process_ui.py
+++ b/process_ui.py
@@ -46,6 +46,8 @@ def send_request(selected_video, reference_court, status_label, stats_button):
             data = resp.json()
             ball_tp = json.loads(data["ball_tp"])
             control_stats = json.loads(data["control_stats"])
+            pi_stats = json.loads(data['pi_stats'])
+
             vid_name = data["vid_name"]
             x, y = possession_to_percentages(ball_tp)
             path = possession_plot(x, y, vid_name)
@@ -54,6 +56,22 @@ def send_request(selected_video, reference_court, status_label, stats_button):
             ctrl_path = control_plot(control_stats, vid_name)
 
             s3_upload(ctrl_path, f"{vid_name}_mm.png", "figures")
+
+            pi_stats = [
+                {
+                    int(k): v
+                    for k, v in frame.items()
+                }
+                for frame in pi_stats
+            ]
+            p1, p2, i1, i2 = extract_timeseries(pi_stats)
+            frames = list(range(len(pi_stats)))
+            passes_path = passes_plot(frames, p1, p2, vid_name)
+            interceptions_path = interceptions_plot(frames, i1, i2, vid_name)
+
+            s3_upload(passes_path, f"{vid_name}_passes.png", "figures")
+            s3_upload(interceptions_path, f"{vid_name}_interceptions.png", "figures")
+
 
             status_label.config(text="Done!", fg="green")
             stats_button.config(state="normal") 
@@ -66,6 +84,89 @@ def send_request(selected_video, reference_court, status_label, stats_button):
     except Exception as e:
         status_label.config(text="Error!", fg="red")
         messagebox.showerror("Exception", str(e))
+
+def to_percent(v1, v2):
+    v1 = np.array(v1, dtype=float)
+    v2 = np.array(v2, dtype=float)
+
+    pct = np.zeros_like(v1, dtype=float)
+
+    for i in range(len(v1)):
+        a, b = v1[i], v2[i]
+        if a == 0 and b == 0:
+            pct[i] = 0.5
+        elif a > 0 and b == 0:
+            pct[i] = 1.0
+        elif a == 0 and b > 0:
+            pct[i] = 0.0
+        else:  # both >0
+            pct[i] = a / (a + b)
+
+    return pct
+
+def extract_timeseries(stats):
+    passes_t1 = []
+    passes_t2 = []
+    inter_t1 = []
+    inter_t2 = []
+
+    for frame in stats:
+        t1 = frame.get(1) or frame.get("1")
+        t2 = frame.get(2) or frame.get("2")
+
+        if t1 is None or t2 is None:
+            raise ValueError(f"Bad stats format: {frame}")
+
+        passes_t1.append(t1["Passes"])
+        passes_t2.append(t2["Passes"])
+        inter_t1.append(t1["Interceptions"])
+        inter_t2.append(t2["Interceptions"])
+
+    return passes_t1, passes_t2, inter_t1, inter_t2
+
+def passes_plot(frames, passes_t1, passes_t2, video_name):
+    pct = to_percent(passes_t1, passes_t2)
+    return percent_style_plot(
+        frames, pct, video_name, label="Passes"
+    )
+
+def interceptions_plot(frames, inter_t1, inter_t2, video_name):
+    pct = to_percent(inter_t1, inter_t2)
+    return percent_style_plot(
+        frames, pct, video_name, label="Interceptions"
+    )
+
+def percent_style_plot(x, pct_team1, video_name, label):
+    y_percent = pct_team1 * 100
+
+    fig, ax_left = plt.subplots(figsize=(14, 4))
+    ax_right = ax_left.twinx()
+
+    for i, val in enumerate(y_percent):
+        ax_left.bar(i, val, color="#9eaec6", width=1.0)            
+        ax_left.bar(i, 100 - val, bottom=val, color="#9cb2a0", width=1.0)
+
+    ax_left.plot(x, y_percent, color="black", linewidth=2)
+
+    ax_left.set_ylim(0, 100)
+    ax_left.set_yticks(np.arange(0, 101, 5))
+    ax_left.set_ylabel(f"Team A {label} (%)")
+
+    ax_right.set_ylim(100, 0)
+    ax_right.set_yticks(np.arange(0, 101, 5))
+    ax_right.set_ylabel(f"Team B {label} (%)")
+
+    ax_left.set_xlim(0, len(x))
+    ax_left.set_xlabel("Frames")
+
+    plt.tight_layout()
+    folder = f"figures/{label}"
+    os.makedirs(folder, exist_ok=True)
+    path = os.path.join(folder, f"{video_name}.png")
+    fig.savefig(path, dpi=300)
+    plt.close(fig)
+
+    return path
 
 def possession_plot(x, y, video_name):
     y_percent = np.array(y) * 100

--- a/services/orchestrator_service/orchestrator_service.py
+++ b/services/orchestrator_service/orchestrator_service.py
@@ -46,6 +46,9 @@ async def process_video(video_name: str, reference_court: str):
     ball_sensor = BallAcquisitionSensor()
     ball_acquisition_list = ball_sensor.detect_ball_possession(player_tracks, ball_tracks)
 
+    # 4.1) Passes and interceptions per team
+    passes_and_interceptions = ball_sensor.get_ball_possession_statistics(team_assignments, ball_tracks)
+
     ball_team_possessions = id_to_team_ball_acquisition(ball_acquisition_list,
                                                         team_assignments)   
 
@@ -102,7 +105,8 @@ async def process_video(video_name: str, reference_court: str):
         "status": "completed",
         "ball_tp": f"{ball_team_possessions}",
         "vid_name": f"{video_name}",
-        "control_stats": json.dumps(control_stats)
+        "control_stats": json.dumps(control_stats),
+        'pi_stats': json.dumps(passes_and_interceptions)
     })
 
 if __name__ == "__main__":

--- a/services/video_viewer_service/video_viewer_api.py
+++ b/services/video_viewer_service/video_viewer_api.py
@@ -105,6 +105,16 @@ def video_statistics(video_name: str):
              alt="Ball Possession Plot"
              style="width:100%; border:1px solid #ccc; margin-top:10px;"/>
 
+        <h3 style="margin-top: 20px;">Passes Per Team Plot</h3>
+        <img src="/stats_image/{video_name}_passes"
+             alt="Ball Possession Plot"
+             style="width:100%; border:1px solid #ccc; margin-top:10px;"/>
+        
+        <h3 style="margin-top: 20px;">Interceptions Per Team Plot</h3>
+        <img src="/stats_image/{video_name}_interceptions"
+             alt="Ball Possession Plot"
+             style="width:100%; border:1px solid #ccc; margin-top:10px;"/>
+
     </body>
     </html>
     """


### PR DESCRIPTION
### Statistics regarding passing and intercepting of the ball.

Get the statistics regarding passes and interceptions per the two different teams #24.

Works via checking the teams of the players possessing the ball. We check the team of the current player holding the ball against the team of the player that holds the ball next.

### Two scenarios:
- If the team of current player and next player is the same we add to 1 to the # of passes for the team of the current player.
- If the team of the current player differs from the team of the next player, we instead add 1 to the # of interceptions for the team of the next player.

### Current Issues:
This is heavily bottlenecked by the ball acq sensor module. Currently the statistics very wrong, the images attached are for video_2. The issue arises due to the ball acq sensor wrongfully detecting players possessing the ball when they infact do not. This problem is mostly apparent in the case when the ball is being passed from one player to another, in transit the player which are in the travel path of the ball are recognized as being in possession of it when they where not. Generally speaking, the players of the opposing teams want to block the travel path of the ball for the other team. Which casuses a lot of passes to be counted as interceptions, since there is often a player of the opposing team in the travel path of the ball.

### Plots demonstrating feature.
<img width="4200" height="1200" alt="video_2" src="https://github.com/user-attachments/assets/a4909be2-f1a2-4501-81e5-0c481d06e44a" />
<img width="4200" height="1200" alt="video_2" src="https://github.com/user-attachments/assets/5b6da2c3-9019-4fff-a0fd-d70bc3fa2ba2" />
